### PR TITLE
Add battery level indicator

### DIFF
--- a/src/config/BatteryConfig.cpp
+++ b/src/config/BatteryConfig.cpp
@@ -23,27 +23,15 @@ void BatteryConfig::checkBatteryLevel() {
 
     // Convert the raw value to voltage
     float batteryVoltage = (float) rawValue / 4095.0 * 3.3 * 2 * 1.05;
-//    float battv = (float) rawValue / 4095.0 * 3.3;
 
     Logger.print(__FILE__, __LINE__, "Voltage on GPIO 13: ", batteryVoltage, " V");
 
     // Calculate the battery percentage
-//    uint8_t batteryPercentage = (uint8_t) (((batteryVoltage - BATTV_MIN) / (BATTV_MAX - BATTV_MIN)) * 100);
+    auto batteryPercentage = (uint8_t) (((batteryVoltage - BATTV_MIN) / (BATTV_MAX - BATTV_MIN)) * 100);
 
-//    float tempBattpc = ((battv - BATTV_MIN) / (BATTV_MAX - BATTV_MIN)) * 100;
-//    uint8_t battpc = tempBattpc > 100 ? 100 : (uint8_t) tempBattpc;
-
-    // Calculate the battery percentage
-    uint8_t batteryPercentage = (uint8_t) (((batteryVoltage - BATTV_MIN) / (BATTV_MAX - BATTV_MIN)) * 100);
-
-    // Create a string with the battery level information
     char batteryLevelStr[50];
     sprintf(batteryLevelStr, "Battery level: %d%%", batteryPercentage);
-
-    // Pass the string to the Logger.print function
     Logger.print(__FILE__, __LINE__, batteryLevelStr);
-
-//    Logger.print(__FILE__, __LINE__, "Battery level: ", batteryPercentage, "%");
 
     // Check if the battery voltage is low
     if (batteryVoltage < BATTV_LOW) {

--- a/src/config/BatteryConfig.cpp
+++ b/src/config/BatteryConfig.cpp
@@ -1,0 +1,52 @@
+#include "BatteryConfig.h"
+#include "utils/BatteryPins.h"
+#include "utils/CustomSerial.h"
+#include "Arduino.h"
+
+void BatteryConfig::initialize() {
+    // Set the battery pin as an input
+    pinMode(VBAT_PIN, INPUT);
+}
+
+void BatteryConfig::checkBatteryLevel() {
+    // Read the raw value from the battery pin
+    int rawValue = analogRead(VBAT_PIN);
+
+    // Print the raw value
+    Logger.print(__FILE__, __LINE__, "Raw value of what's in pin GPIO 13: ", rawValue);
+
+    // Check if the raw value is 0
+    if (rawValue == 0) {
+        Logger.print(__FILE__, __LINE__, "Error: No reading from battery level pin");
+        return;
+    }
+
+    // Convert the raw value to voltage
+    float batteryVoltage = (float) rawValue / 4095.0 * 3.3 * 2 * 1.05;
+//    float battv = (float) rawValue / 4095.0 * 3.3;
+
+    Logger.print(__FILE__, __LINE__, "Voltage on GPIO 13: ", batteryVoltage, " V");
+
+    // Calculate the battery percentage
+//    uint8_t batteryPercentage = (uint8_t) (((batteryVoltage - BATTV_MIN) / (BATTV_MAX - BATTV_MIN)) * 100);
+
+//    float tempBattpc = ((battv - BATTV_MIN) / (BATTV_MAX - BATTV_MIN)) * 100;
+//    uint8_t battpc = tempBattpc > 100 ? 100 : (uint8_t) tempBattpc;
+
+    // Calculate the battery percentage
+    uint8_t batteryPercentage = (uint8_t) (((batteryVoltage - BATTV_MIN) / (BATTV_MAX - BATTV_MIN)) * 100);
+
+    // Create a string with the battery level information
+    char batteryLevelStr[50];
+    sprintf(batteryLevelStr, "Battery level: %d%%", batteryPercentage);
+
+    // Pass the string to the Logger.print function
+    Logger.print(__FILE__, __LINE__, batteryLevelStr);
+
+//    Logger.print(__FILE__, __LINE__, "Battery level: ", batteryPercentage, "%");
+
+    // Check if the battery voltage is low
+    if (batteryVoltage < BATTV_LOW) {
+        Logger.print(__FILE__, __LINE__, "Low battery!");
+    }
+}

--- a/src/config/BatteryConfig.h
+++ b/src/config/BatteryConfig.h
@@ -1,0 +1,11 @@
+#ifndef BATTERYCONFIG_H
+#define BATTERYCONFIG_H
+
+class BatteryConfig {
+
+public:
+    static void initialize();
+    static void checkBatteryLevel();
+};
+
+#endif //BATTERYCONFIG_H

--- a/src/config/WiFiConfig.cpp
+++ b/src/config/WiFiConfig.cpp
@@ -1,11 +1,35 @@
 #include "WiFiConfig.h"
-#include <WiFiManager.h>
+#include "WiFi.h"
+
+const char *ssid = "Speedy-Fibra-C19";
+const char *password = "qazwsxed";
 
 bool WiFiConfig::connect() {
-    WiFiClass::mode(WIFI_STA); // explicitly set mode, esp defaults to STA+AP
-    WiFiManager wm;
+    WiFi.begin(ssid, password);
 
-    wm.resetSettings();
-    wm.setConnectTimeout(60);
-    return wm.autoConnect("AutoConnectAP","12345678");
+    while (WiFiClass::status() != WL_CONNECTED) {
+        delay(1000);
+        Logger.print(__FILE__, __LINE__, "Connecting to WiFi...\n");
+    }
+
+    if (WiFiClass::status() == WL_CONNECTED) {
+        Logger.print(__FILE__, __LINE__, "Connected to WiFi! IP address: ", WiFi.localIP().toString().c_str());
+        return true;
+    } else {
+        return false;
+    }
+}
+
+void WiFiConfig::disconnect() {
+//    WiFi.disconnect();
+    WiFiClass::mode(WIFI_OFF);
+}
+
+void WiFiConfig::reconnect() {
+    WiFi.begin(ssid, password);
+
+    while (WiFiClass::status() != WL_CONNECTED) {
+        delay(1000);
+        return;
+    }
 }

--- a/src/config/WiFiConfig.h
+++ b/src/config/WiFiConfig.h
@@ -1,7 +1,9 @@
 #ifndef WIFICONFIG_H
 #define WIFICONFIG_H
 
+#include <Preferences.h>
 #include "WiFi.h"
+#include "WiFiManager.h"
 #include "utils/CustomSerial.h"
 
 class WiFiConfig {
@@ -11,6 +13,9 @@ public:
     static void disconnect();
 
     static void reconnect();
+
+private:
+    static Preferences preferences;
 };
 
 #endif //WIFICONFIG_H

--- a/src/config/WiFiConfig.h
+++ b/src/config/WiFiConfig.h
@@ -7,6 +7,10 @@
 class WiFiConfig {
 public:
     static bool connect();
+
+    static void disconnect();
+
+    static void reconnect();
 };
 
 #endif //WIFICONFIG_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,23 +11,6 @@
 #include "handler/TemperatureHumiditySensorHandler.h"
 #include "utils/CustomSerial.h"
 #include "config/BatteryConfig.h"
-#include <driver/adc.h>
-
-void readGPIO13() {
-    float ADbits = 4095.0f;
-    float uPvolts = 3.3f;
-    float adcValue = 0.0f;
-    TickType_t xLastWakeTime = xTaskGetTickCount();
-    const TickType_t xFrequency = 100; //delay for mS
-    for (;;) {
-        adcValue = float(adc1_get_raw(ADC1_CHANNEL_4)); //take a raw ADC reading from GPIO 13
-        adcValue = (adcValue * uPvolts) / ADbits; //calculate voltage
-        Logger.print(__FILE__, __LINE__, "Voltage on GPIO 13: %.2f V", adcValue);
-        xLastWakeTime = xTaskGetTickCount();
-        vTaskDelayUntil(&xLastWakeTime, xFrequency);
-    }
-    vTaskDelete(NULL);
-} // end readGPIO13()
 
 void setup() {
     delay(5000);
@@ -55,8 +38,7 @@ void setup() {
 
     TimeConfig::initialize();
 
-//    BatteryConfig::initialize();
-//    pinMode(13, INPUT);
+    BatteryConfig::initialize();
 
     auto *statusEndpoint = new Endpoint("/status", HTTP_GET, StatusHandler::handle);
     Logger.print(__FILE__, __LINE__, "Status endpoint created! Go to http://", WiFi.localIP().toString().c_str(),
@@ -86,20 +68,18 @@ void setup() {
     } else {
         Logger.print(__FILE__, __LINE__, "HTTP server started");
     }
-
 }
 
 void loop() {
-    delay(10000);
+    delay(100000);
 
     if (WiFiClass::status() != WL_CONNECTED) {
         Logger.print(__FILE__, __LINE__, "WiFi disconnected");
         return;
     }
 
+    // Battery check doesn't work when WiFi is connected
     WiFiConfig::disconnect();
-    delay(1000);
     BatteryConfig::checkBatteryLevel();
     WiFiConfig::reconnect();
-    delay(1000);
 }

--- a/src/utils/BatteryPins.h
+++ b/src/utils/BatteryPins.h
@@ -1,0 +1,9 @@
+#ifndef BATTERYPINS_H
+#define BATTERYPINS_H
+
+#define VBAT_PIN 13
+#define BATTV_MAX    3.3     // maximum voltage of battery
+#define BATTV_MIN    2.5     // what we regard as an empty battery
+#define BATTV_LOW    3.1     // voltage considered to be low battery
+
+#endif //BATTERYPINS_H


### PR DESCRIPTION
## Battery Level Indicator
We've introduced a battery level indicator for the 18650 Li-Ion cell used in the project. This feature allows us to monitor the battery level and understand when it's getting low. We've achieved this by implementing a voltage divider circuit and reading the voltage via an ADC pin on the ESP32 board. The reading is then converted to a rough battery percentage, providing a useful indication of the remaining battery life.  

## WiFi Reconnection Logic
We've added logic to disconnect from WiFi when checking the battery level. This is due to the fact that the ADC pin used for battery level checking doesn't function correctly when WiFi is on. After the battery level check, the device reconnects to WiFi using saved credentials.

![image](https://github.com/FrancoBre/ESP32-camera-streamer/assets/66085255/39267efc-40e2-4f6b-bdc3-328d7cc072f8)
